### PR TITLE
MGL AST to GML script, part 1

### DIFF
--- a/examples/hello_project/src/hello.mgl
+++ b/examples/hello_project/src/hello.mgl
@@ -1,0 +1,4 @@
+function hello(s) {
+  print("hello " + s)
+}
+

--- a/src/ast/operators.rs
+++ b/src/ast/operators.rs
@@ -1,6 +1,7 @@
 pub trait Operator {
   fn priority(self) -> i64;
   fn from_str(s: &str) -> Self;
+  fn as_str(&self) -> &'static str;
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -58,6 +59,15 @@ impl Operator for UnaryOp {
     }
   }
 
+  fn as_str(&self) -> &'static str {
+    use UnaryOp::*;
+
+    match self {
+      Neg => "-",
+      Not => "!",
+    }
+  }
+
   fn priority(self) -> i64 {
     use UnaryOp::*;
 
@@ -89,6 +99,26 @@ impl Operator for BinaryOp {
       "==" => Eq,
       "!=" => Diff,
       _ => unreachable!()
+    }
+  }
+
+  fn as_str(&self) -> &'static str {
+    use BinaryOp::*;
+
+    match self {
+      Dot  => ".",
+      Add  => "+",
+      Sub  => "-",
+      Mul  => "*",
+      Div  => "/",
+      Or   => "||",
+      And  => "&&",
+      Lt   => "<",
+      Gt   => ">",
+      Geq  => ">=",
+      Leq  => "<=",
+      Eq   => "==",
+      Diff => "!=",
     }
   }
 
@@ -127,6 +157,18 @@ impl Operator for Accessor {
       "#" => Grid,
       "@" => Array,
       _ => unreachable!()
+    }
+  }
+
+  fn as_str(&self) -> &'static str {
+    use Accessor::*;
+
+    match self {
+      None  => "",
+      List  => "|",
+      Map   => "?",
+      Grid  => "#",
+      Array => "@",
     }
   }
 

--- a/src/command_line.rs
+++ b/src/command_line.rs
@@ -12,6 +12,7 @@ pub enum Action {
   Compile,
   ShowAst(bool),
   Project(bool),
+  Scripts,
 }
 
 
@@ -62,6 +63,10 @@ fn generate_app<'a, 'b>() -> App<'a, 'b> {
     .subcommand(SubCommand::with_name("project")
                 .about("Show final project output as text")
                 .arg(pretty))
+
+    .subcommand(SubCommand::with_name("scripts")
+                .about("compile just the scripts and print them"))
+
 }
 
 
@@ -81,6 +86,7 @@ fn interpret_subcommand(matches: &ArgMatches) -> Action {
     ("compile", _) => Action::Compile,
     ("project", m) => Action::Project(interpret_pretty(&m.unwrap())),
     ("ast",     m) => Action::ShowAst(interpret_pretty(&m.unwrap())),
+    ("scripts", _) => Action::Scripts,
     _ => unreachable!()
   }
 }

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -1,3 +1,4 @@
 pub mod file_reader;
 pub mod resource_tree;
+pub mod script;
 

--- a/src/compiler/script.rs
+++ b/src/compiler/script.rs
@@ -1,0 +1,182 @@
+use crate::ast::*;
+use crate::resources::script::*;
+
+struct StatementBuilder {
+  root: bool,
+  result: String,
+  indentation: usize,
+}
+
+pub fn build_script(s: Script) -> String {
+  let source = &s.source;
+
+  let mut builder = StatementBuilder::new(true, 0);
+  builder.argument_vars(&source.args);
+  builder.build_statement(source.body.as_ref());
+
+  format!("{}", builder.result)
+}
+
+fn build_expression(e: &Expression) -> String {
+  use crate::ast::BinaryOp::Dot;
+  use Expression::*;
+  let ex = build_expression;
+
+  match &e {
+    &Str(string)         => format!("\"{}\"", string),
+    &Num(number)         => number.clone(),
+    &Bool(true)          => String::from("true"),
+    &Bool(false)         => String::from("false"),
+    &Name(name)          => name.clone(),
+    &Resource(name)      => build_resource_name(&name),
+    &Parentheses(e)      => format!("({})", build_expression(&*e)),
+    &UnaryOp(op, e)      => format!("{}{}", op.as_str(), build_expression(&*e)),
+    &BinaryOp(Dot, a, b) => format!("{}.{}", ex(&*a), ex(&*b)),
+    &BinaryOp(op, a, b)  => format!("{} {} {}", ex(&*a), op.as_str(), ex(&*b)),
+    &Call(f, args)       => build_call(&*f, &args),
+    &Indexing(v, a, k)   => build_indexing(&*v, *a, &k),
+    &TernaryOp(_,_,_)    => unreachable!()
+  }
+}
+
+fn build_resource_name(name: &ResourceName) -> String {
+  match &name {
+    &ResourceName::Name(name) => name.clone(),
+    &ResourceName::InModule(m, n) => {
+      format!("{}__{}", m, build_resource_name(&*n))
+    }
+  }
+}
+
+
+fn join_arguments(v: &Vec<Expression>) -> String {
+  v.iter().map(build_expression).collect::<Vec<_>>().join(", ")
+}
+
+fn build_call(caller: &Expression, args: &Vec<Expression>) -> String {
+  let mut result = build_expression(caller);
+
+  result.push('(');
+  result.push_str(&join_arguments(args));
+  result.push(')');
+
+  result
+}
+
+fn build_indexing(v: &Expression, op: Accessor, keys: &Vec<Expression>) -> String {
+  let mut result = build_expression(v);
+
+  result.push('[');
+  result.push_str(op.as_str());
+  result.push_str(&join_arguments(keys));
+  result.push(']');
+
+  result
+}
+
+
+fn build_for_range(var: &str, f: &ForRange) -> String {
+  match f {
+    ForRange::Integer(from, to, Some(by)) => {
+      let from = build_expression(from);
+      let to   = build_expression(to);
+      let by   = build_expression(by);
+      format!("var {v} = {}; {v} != {}; {v} += {}", from, to, by, v=var)
+    }
+    _ => unreachable!()
+  }
+}
+
+
+impl StatementBuilder {
+  fn new(root: bool, indentation: usize) -> Self {
+    StatementBuilder {
+      root,
+      result: String::new(),
+      indentation
+    }
+  }
+
+  fn add(&mut self, line: &str) {
+    self.result.push_str(&format!("{}{}", " ".repeat(self.indentation), line));
+  }
+
+  fn argument_vars(&mut self, args: &Vec<String>) {
+    let mut i = 0;
+    for argument in args {
+      self.add(&format!("var {} = argument{};\n", argument, i));
+      i += 1;
+    }
+  }
+
+  fn build_statement(&mut self, statement: &Statement) {
+    match &statement {
+      &Statement::Return(expr) => {
+        self.add(&format!("return {};\n", build_expression(&expr)));
+      }
+
+      &Statement::Call(expr) => {
+        self.add(&format!("{};\n", build_expression(&expr)));
+      }
+
+      &Statement::Body(statements) => {
+        let indentation = if self.root {0} else {self.indentation + 4};
+        let mut builder = StatementBuilder::new(false, indentation);
+        for statement in statements {
+          builder.build_statement(statement);
+        }
+        self.add(&builder.result);
+      }
+
+      &Statement::With(with, body) => {
+        self.add(&format!("with {} {{\n", build_expression(with)));
+        self.build_statement(body);
+        self.add("}\n");
+      }
+
+      &Statement::If(cond, then, or_else) => {
+        self.add(&format!("if {} {{\n", build_expression(cond)));
+        self.build_statement(then);
+
+        if let Some(or_else) = or_else {
+          self.add("} else {\n");
+          self.build_statement(or_else);
+        }
+        self.add("}\n");
+      }
+
+      &Statement::While(cond, body) => {
+        self.add(&format!("while {} {{\n", build_expression(cond)));
+        self.build_statement(body);
+        self.add("}\n");
+      }
+
+      &Statement::For(var, range, body) => {
+        self.add(&format!("for ({}) {{\n", build_for_range(&var, &range)));
+        self.build_statement(body);
+        self.add("}\n");
+      }
+
+      Statement::Assignment(left, right) => {
+        self.add(&format!("{} = {};\n", build_expression(left), build_expression(right)));
+      }
+
+      Statement::Var(vars) => {
+        let mut parts = Vec::new();
+
+        for var in vars {
+          match var {
+            VarDeclaration::Assignment(var, expr) => {
+              parts.push(format!("{} = {}", var, build_expression(expr)));
+            }
+            VarDeclaration::Name(var) => {
+              parts.push(var.clone())
+            }
+          }
+        }
+        self.add(&format!("var {};\n", parts.join(", ")));
+      }
+    }
+  }
+}
+

--- a/src/tests/ast/mod.rs
+++ b/src/tests/ast/mod.rs
@@ -1,3 +1,4 @@
+mod operators;
 mod convert;
 mod from_str;
 

--- a/src/tests/ast/operators.rs
+++ b/src/tests/ast/operators.rs
@@ -1,0 +1,29 @@
+use crate::ast::*;
+
+macro assert_operator_name($T: ty, $op: expr) {
+  assert_eq!(<$T>::from_str($op).as_str(), $op)
+}
+
+#[test]
+fn test_ast_operator_names() {
+  assert_operator_name!(BinaryOp, ".");
+  assert_operator_name!(BinaryOp, "+");
+  assert_operator_name!(BinaryOp, "-");
+  assert_operator_name!(BinaryOp, "*");
+  assert_operator_name!(BinaryOp, "/");
+  assert_operator_name!(BinaryOp, "||");
+  assert_operator_name!(BinaryOp, "&&");
+  assert_operator_name!(BinaryOp, "<");
+  assert_operator_name!(BinaryOp, ">");
+  assert_operator_name!(BinaryOp, ">=");
+  assert_operator_name!(BinaryOp, "<=");
+  assert_operator_name!(BinaryOp, "==");
+  assert_operator_name!(BinaryOp, "!=");
+  assert_operator_name!(UnaryOp,  "-");
+  assert_operator_name!(UnaryOp,  "!");
+  assert_operator_name!(Accessor, "");
+  assert_operator_name!(Accessor, "|");
+  assert_operator_name!(Accessor, "?");
+  assert_operator_name!(Accessor, "#");
+  assert_operator_name!(Accessor, "@");
+}

--- a/src/tests/compiler/mod.rs
+++ b/src/tests/compiler/mod.rs
@@ -1,1 +1,3 @@
 mod file_reader;
+mod script;
+

--- a/src/tests/compiler/script.rs
+++ b/src/tests/compiler/script.rs
@@ -1,0 +1,119 @@
+use crate::tests::utility::*;
+use crate::compiler::script::*;
+use crate::resources::script::*;
+
+fn script(source: &str) -> String {
+  build_script(Script::global(function(source)))
+}
+
+fn func(body: &str) -> String {
+  format!("function f() {{{}\n}}", body)
+}
+
+fn assert_script_eq(source: &str, expected: &str) {
+  assert_eq!(script(source).trim(), expected.trim());
+}
+
+const RESULT_ARGS: &str = r#"
+var a = argument0;
+var b = argument1;
+"#;
+
+#[test]
+fn test_compiler_script_arguments() {
+  assert_script_eq("function f(a,b) {}", RESULT_ARGS);
+}
+
+#[test]
+fn test_compiler_script_return() {
+  assert_script_eq("function f() {return 0\n}", "return 0;");
+}
+
+#[test]
+fn test_compiler_script_expressions() {
+  let ex = |e: &str| format!("function f() {{return {}\n}}", e);
+  assert_script_eq(&ex("\"abc\""), "return \"abc\";");
+  assert_script_eq(&ex("0"),       "return 0;");
+  assert_script_eq(&ex("true"),    "return true;");
+  assert_script_eq(&ex("false"),   "return false;");
+  assert_script_eq(&ex("abc"),     "return abc;");
+  assert_script_eq(&ex("m::n"),    "return m__n;");
+  assert_script_eq(&ex("(x)"),     "return (x);");
+  assert_script_eq(&ex("-x"),      "return -x;");
+  assert_script_eq(&ex("x + y"),   "return x + y;");
+  assert_script_eq(&ex("x.y"),     "return x.y;");
+  assert_script_eq(&ex("f(x,y)"),  "return f(x, y);");
+  assert_script_eq(&ex("a[@x]"),   "return a[@x];");
+}
+
+#[test]
+fn test_compiler_script_call() {
+  assert_script_eq(&func("print(x)"), "print(x);");
+}
+
+#[test]
+fn test_compiler_script_assign() {
+  assert_script_eq(&func("a = b"), "a = b;");
+}
+
+#[test]
+fn test_compiler_script_var() {
+  assert_script_eq(&func("var a"),        "var a;");
+  assert_script_eq(&func("var a, b"),     "var a, b;");
+  assert_script_eq(&func("var a = 1, b"), "var a = 1, b;");
+}
+
+const RESULT_WITH: &str = r#"
+with obj {
+    print(obj.x);
+}
+"#;
+
+#[test]
+fn test_compiler_script_with() {
+  assert_script_eq(&func("with obj {print(obj.x)\n}"), RESULT_WITH);
+}
+
+
+const RESULT_IF: &str = r#"
+if a > b {
+    return a - b;
+}
+"#;
+
+const RESULT_IF_ELSE: &str = r#"
+if k {
+    f(x);
+} else {
+    f(y);
+}
+"#;
+
+#[test]
+fn test_compiler_script_if() {
+  assert_script_eq(&func("if a > b {return a - b\n}"), RESULT_IF);
+  assert_script_eq(&func("if k {f(x)\n} else {f(y)\n}"), RESULT_IF_ELSE);
+}
+
+const RESULT_WHILE: &str = r#"
+while i <= len {
+    i = i + 1;
+}
+"#;
+
+#[test]
+fn test_compiler_script_while() {
+  assert_script_eq(&func("while i <= len {i = i + 1\n}"), RESULT_WHILE);
+}
+
+const RESULT_FOR: &str = r#"
+for (var i = 0; i != 10; i += 1) {
+    print(i);
+}
+"#;
+
+#[test]
+fn test_compiler_script_for() {
+  assert_script_eq(&func("for i in 0..10 by 1 {print(i)\n}"), RESULT_FOR);
+}
+


### PR DESCRIPTION
This allows a (fully lowered) ast to be transformed into a gml script. This will require a earlier lowering step to work with all ASTs, most likely the same one that will manipulate constant expressions, or a step adjacent to it.